### PR TITLE
ROS2 Humble Migration for PAL Person Detector OpenCV

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 cmake_minimum_required(VERSION 2.8.3)
 project(pal_person_detector_opencv)
 
@@ -19,3 +20,69 @@ target_link_libraries(pal_person_detector_opencv ${catkin_LIBRARIES} ${OpenCV_LI
 
 install(TARGETS pal_person_detector_opencv
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+=======
+cmake_minimum_required(VERSION 3.8)
+project(pal_person_detector_opencv)
+
+# Default to C++14 for ROS2 Humble
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# Find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(image_transport REQUIRED)
+find_package(cv_bridge REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(OpenCV REQUIRED)
+
+# Generate messages
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/Detection2d.msg"
+  "msg/Detections2d.msg"
+  DEPENDENCIES std_msgs geometry_msgs
+)
+
+# Create executable - note the name is different from the project name
+add_executable(person_detector_node src/person_detector.cpp)
+target_include_directories(person_detector_node PRIVATE
+  ${OpenCV_INCLUDE_DIRS}
+)
+ament_target_dependencies(person_detector_node
+  rclcpp
+  image_transport
+  cv_bridge
+  sensor_msgs
+  geometry_msgs
+  std_msgs
+)
+target_link_libraries(person_detector_node
+  ${OpenCV_LIBRARIES}
+)
+
+# Use the new rosidl_get_typesupport_target() approach instead of deprecated rosidl_target_interfaces()
+rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
+target_link_libraries(person_detector_node "${cpp_typesupport_target}")
+
+# Install
+install(TARGETS
+  person_detector_node
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+# Install launch files
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()
+>>>>>>> ccd9c4e (ROS2 Humble migration)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 # pal_person_detector_opencv
 ROS node integrating the person detector for RGB images based on OpenCV's HoG Adaboost cascade
 
@@ -28,3 +29,104 @@ The image `/person_detector/debug` shows the processed images with the ROIs corr
 
 
 
+=======
+# PAL Person Detector OpenCV
+
+A ROS2 Humble package for real-time person detection using OpenCV's HOG (Histogram of Oriented Gradients) detector.
+
+## Overview
+
+This package provides a lightweight solution for detecting people in camera feeds using computer vision. It's based on OpenCV's HOG detector and has been optimized for real-time performance on CPU.
+
+The detector:
+- Processes incoming image streams from ROS2 topics
+- Detects people in the images using HOG features
+- Publishes detection results as bounding boxes
+- Provides visualized results for debugging
+
+## Installation
+
+### Prerequisites
+
+- ROS2 Humble
+- OpenCV
+- Image transport plugins
+
+```bash
+# Install dependencies
+sudo apt update
+sudo apt install -y ros-humble-image-transport ros-humble-cv-bridge ros-humble-image-transport-plugins
+```
+
+### Building
+
+```bash
+# Clone into your ROS2 workspace
+git clone https://github.com/username/pal_person_detector_opencv.git
+
+# Build in your Workspace
+colcon build --packages-select pal_person_detector_opencv
+
+# Source the workspace
+source install/setup.bash
+```
+
+## Usage
+
+### Basic Usage
+
+1. Start a camera node
+```bash
+ros2 run v4l2_camera v4l2_camera_node
+```
+
+2. Run the person detector
+```bash
+ros2 launch pal_person_detector_opencv detector.launch.py
+```
+
+3. View results
+```bash
+ros2 run rqt_image_view rqt_image_view
+# Select the "/debug" topic from the dropdown
+```
+
+### Parameters
+
+The detector supports several parameters to adjust performance:
+
+- **image**: Input image topic (default: `/image_raw`)
+- **scale**: Image scaling factor (default: `0.5`, smaller = faster but less accurate)
+- **rate**: Maximum processing rate in Hz (default: `5.0`)
+- **transport**: Image transport type (default: `raw`)
+
+Example:
+```bash
+ros2 launch pal_person_detector_opencv detector.launch.py image:=/camera/image scale:=0.4 rate:=3
+```
+
+## Outputs
+
+The detector publishes to the following topics:
+
+- **/detections**: Detection results as an array of bounding boxes
+- **/debug**: Visualization of detections drawn on the input image
+
+## Applications
+
+This person detector can be used in various scenarios:
+
+- Robot navigation around humans
+- Human-robot interaction systems
+- Surveillance and security
+- People counting and tracking
+- Activity monitoring
+
+## License
+
+This package is licensed under the BSD License. See the LICENSE file for details.
+
+## Credits
+
+Originally developed by PAL Robotics, migrated to ROS2 Humble.
+>>>>>>> ccd9c4e (ROS2 Humble migration)

--- a/launch/detector.launch.py
+++ b/launch/detector.launch.py
@@ -1,0 +1,52 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+def generate_launch_description():
+    # Declare arguments
+    max_rate_arg = DeclareLaunchArgument(
+        'max_rate',
+        default_value='5.0',
+        description='Maximum processing rate'
+    )
+    
+    scale_arg = DeclareLaunchArgument(
+        'scale',
+        default_value='0.5',
+        description='Image scale factor'
+    )
+    
+    image_arg = DeclareLaunchArgument(
+        'image',
+        default_value='/camera/image',
+        description='Input image topic'
+    )
+    
+    transport_arg = DeclareLaunchArgument(
+        'transport',
+        default_value='raw',
+        description='Image transport type'
+    )
+
+    # Create node
+    person_detector_node = Node(
+        package='pal_person_detector_opencv',
+        executable='person_detector_node',  # Updated executable name
+        name='person_detector',
+        output='screen',
+        parameters=[{
+            'image': LaunchConfiguration('image'),
+            'rate': LaunchConfiguration('max_rate'),
+            'scale': LaunchConfiguration('scale'),
+            'transport': LaunchConfiguration('transport')
+        }]
+    )
+
+    return LaunchDescription([
+        max_rate_arg,
+        scale_arg,
+        image_arg,
+        transport_arg,
+        person_detector_node
+    ])

--- a/msg/Detection2d.msg
+++ b/msg/Detection2d.msg
@@ -1,0 +1,12 @@
+# Rectangle defined by a point, its width and height
+# corresponds to the openCV struct : CvRect
+
+# coordinates of the top left corner of the box
+int64 x
+int64 y
+
+# width of the box
+int64 width
+
+# height of the box
+int64 height

--- a/msg/Detections2d.msg
+++ b/msg/Detections2d.msg
@@ -1,0 +1,6 @@
+std_msgs/Header header
+
+Detection2d[]  detections
+
+# Optional transformation between the camera frame and a certain parent frame
+geometry_msgs/TransformStamped camera_pose

--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<<<<<<< HEAD
 <package>
   <name>pal_person_detector_opencv</name>
   <version>0.1.0</version>
@@ -21,3 +22,33 @@
   <run_depend>image_transport</run_depend>
 
 </package>
+=======
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>pal_person_detector_opencv</name>
+  <version>0.1.0</version>
+  <description>
+    ROS2 package for person detection using OpenCV's HOG detector
+  </description>
+  <maintainer email="maintainer@example.com">Maintainer</maintainer>
+  <license>BSD</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  
+  <depend>rclcpp</depend>
+  <depend>image_transport</depend>
+  <depend>cv_bridge</depend>
+  <depend>sensor_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>opencv</depend>
+  
+  <build_depend>rosidl_default_generators</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>
+>>>>>>> ccd9c4e (ROS2 Humble migration)

--- a/src/person_detector.cpp
+++ b/src/person_detector.cpp
@@ -33,6 +33,7 @@
  */
 
 /** \author Jordi Pages <jordi.pages@pal-robotics.com> */
+<<<<<<< HEAD
 
 // PAL headers
 #include <pal_detection_msgs/Detections2d.h>
@@ -44,22 +45,44 @@
 #include <ros/callback_queue.h>
 #include <sensor_msgs/Image.h>
 #include <image_transport/image_transport.h>
+=======
+/** \author Migrated to ROS2 Humble */
+
+// Project message headers
+#include <pal_person_detector_opencv/msg/detections2d.hpp>
+#include <pal_person_detector_opencv/msg/detection2d.hpp>
+
+
+// ROS headers
+#include <rclcpp/rclcpp.hpp>
+#include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <image_transport/image_transport.hpp>
+>>>>>>> ccd9c4e (ROS2 Humble migration)
 
 // OpenCV headers
 #include <opencv2/objdetect/objdetect.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <opencv2/highgui/highgui.hpp>
 
+<<<<<<< HEAD
 // Boost headers
 #include <boost/scoped_ptr.hpp>
 #include <boost/foreach.hpp>
 
 // Std C++ headers
 #include <vector>
+=======
+// Std C++ headers
+#include <vector>
+#include <memory>
+>>>>>>> ccd9c4e (ROS2 Humble migration)
 
 /**
  * @brief The PersonDetector class encapsulating an image subscriber and the OpenCV's CPU HOG person detector
  *
+<<<<<<< HEAD
  * @example rosrun person_detector_opencv person_detector image:=/camera/image _rate:=5 _scale:=0.5
  *
  */
@@ -79,6 +102,19 @@ protected:
   ros::NodeHandle _nh, _pnh;
 
   void imageCallback(const sensor_msgs::ImageConstPtr& msg);
+=======
+ * @example ros2 run pal_person_detector_opencv pal_person_detector_opencv --ros-args -p image:=/camera/image -p rate:=5 -p scale:=0.5
+ *
+ */
+class PersonDetector : public rclcpp::Node
+{
+public:
+  PersonDetector(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+  virtual ~PersonDetector();
+
+protected:
+  void imageCallback(const sensor_msgs::msg::Image::ConstSharedPtr& msg);
+>>>>>>> ccd9c4e (ROS2 Humble migration)
 
   void detectPersons(const cv::Mat& img,
                      std::vector<cv::Rect>& detections);
@@ -91,6 +127,7 @@ protected:
   void publishDebugImage(cv::Mat& img,
                          const std::vector<cv::Rect>& detections) const;
 
+<<<<<<< HEAD
   double _imageScaling;
   mutable cv_bridge::CvImage _cvImgDebug;
 
@@ -128,6 +165,50 @@ PersonDetector::PersonDetector(ros::NodeHandle& nh,
   _detectionPub = _pnh.advertise<pal_detection_msgs::Detections2d>("detections", 1);
 
   cv::namedWindow("person detections");
+=======
+  double image_scaling_;
+  mutable cv_bridge::CvImage cv_img_debug_;
+
+  std::unique_ptr<cv::HOGDescriptor> hog_cpu_;
+
+  image_transport::Subscriber image_sub_;
+  rclcpp::Time img_time_stamp_;
+
+  rclcpp::Publisher<pal_person_detector_opencv::msg::Detections2d>::SharedPtr detection_pub_;
+  image_transport::Publisher im_debug_pub_;
+};
+
+PersonDetector::PersonDetector(const rclcpp::NodeOptions & options)
+: rclcpp::Node("person_detector", options)
+{
+  // Declare and get parameters
+  image_scaling_ = this->declare_parameter<double>("scale", 1.0);
+  double freq = this->declare_parameter<double>("rate", 10.0);
+  std::string img_transport = this->declare_parameter<std::string>("transport", "raw");
+  std::string topic = this->declare_parameter<std::string>("image", "/camera/image");
+  
+  RCLCPP_INFO(this->get_logger(), "Setting image scale factor to: %f", image_scaling_);
+  RCLCPP_INFO(this->get_logger(), "Setting detector max rate to: %f", freq);
+  RCLCPP_INFO(this->get_logger(), "Image type: %s", img_transport.c_str());
+  RCLCPP_INFO(this->get_logger(), "Creating person detector ...");
+
+  hog_cpu_ = std::make_unique<cv::HOGDescriptor>();
+  hog_cpu_->setSVMDetector(cv::HOGDescriptor::getDefaultPeopleDetector());
+
+  // Setup image transport
+  image_sub_ = image_transport::create_subscription(
+    this, topic,
+    std::bind(&PersonDetector::imageCallback, this, std::placeholders::_1),
+    img_transport);
+
+  // Create publishers
+  detection_pub_ = this->create_publisher<pal_person_detector_opencv::msg::Detections2d>("detections", 1);
+  im_debug_pub_ = image_transport::create_publisher(this, "debug");
+
+  cv::namedWindow("person detections");
+
+  RCLCPP_INFO(this->get_logger(), "Person detector initialized and spinning...");
+>>>>>>> ccd9c4e (ROS2 Humble migration)
 }
 
 PersonDetector::~PersonDetector()
@@ -135,11 +216,16 @@ PersonDetector::~PersonDetector()
   cv::destroyWindow("person detections");
 }
 
+<<<<<<< HEAD
 void PersonDetector::imageCallback(const sensor_msgs::ImageConstPtr& msg)
+=======
+void PersonDetector::imageCallback(const sensor_msgs::msg::Image::ConstSharedPtr& msg)
+>>>>>>> ccd9c4e (ROS2 Humble migration)
 {
   cv_bridge::CvImageConstPtr cvImgPtr;
   cvImgPtr = cv_bridge::toCvShare(msg);
 
+<<<<<<< HEAD
   _imgTimeStamp = msg->header.stamp;
 
   cv::Mat img(static_cast<int>(_imageScaling*cvImgPtr->image.rows),
@@ -147,6 +233,15 @@ void PersonDetector::imageCallback(const sensor_msgs::ImageConstPtr& msg)
               cvImgPtr->image.type());
 
   if ( _imageScaling == 1.0 )
+=======
+  img_time_stamp_ = msg->header.stamp;
+
+  cv::Mat img(static_cast<int>(image_scaling_ * cvImgPtr->image.rows),
+              static_cast<int>(image_scaling_ * cvImgPtr->image.cols),
+              cvImgPtr->image.type());
+
+  if (image_scaling_ == 1.0)
+>>>>>>> ccd9c4e (ROS2 Humble migration)
     cvImgPtr->image.copyTo(img);
   else
   {
@@ -157,11 +252,19 @@ void PersonDetector::imageCallback(const sensor_msgs::ImageConstPtr& msg)
 
   detectPersons(img, detections);
 
+<<<<<<< HEAD
   if ( _imageScaling != 1.0 )
   {
     scaleDetections(detections,
                     static_cast<double>(cvImgPtr->image.cols)/static_cast<double>(img.cols),
                     static_cast<double>(cvImgPtr->image.rows)/static_cast<double>(img.rows));
+=======
+  if (image_scaling_ != 1.0)
+  {
+    scaleDetections(detections,
+                    static_cast<double>(cvImgPtr->image.cols) / static_cast<double>(img.cols),
+                    static_cast<double>(cvImgPtr->image.rows) / static_cast<double>(img.rows));
+>>>>>>> ccd9c4e (ROS2 Humble migration)
   }
 
   publishDetections(detections);
@@ -173,7 +276,11 @@ void PersonDetector::imageCallback(const sensor_msgs::ImageConstPtr& msg)
 void PersonDetector::scaleDetections(std::vector<cv::Rect>& detections,
                                      double scaleX, double scaleY) const
 {
+<<<<<<< HEAD
   BOOST_FOREACH(cv::Rect& detection, detections)
+=======
+  for (auto& detection : detections)
+>>>>>>> ccd9c4e (ROS2 Humble migration)
   {
     cv::Rect roi(detection);
     detection.x      = static_cast<long>(roi.x      * scaleX);
@@ -183,6 +290,7 @@ void PersonDetector::scaleDetections(std::vector<cv::Rect>& detections,
   }
 }
 
+<<<<<<< HEAD
 
 void PersonDetector::detectPersons(const cv::Mat& img,
                                    std::vector<cv::Rect>& detections)
@@ -190,20 +298,37 @@ void PersonDetector::detectPersons(const cv::Mat& img,
   double start = static_cast<double>(cv::getTickCount());
 
   _hogCPU->detectMultiScale(img,
+=======
+void PersonDetector::detectPersons(const cv::Mat& img,
+                                   std::vector<cv::Rect>& detections)
+{
+  double start = static_cast<double>(cv::getTickCount());
+
+  hog_cpu_->detectMultiScale(img,
+>>>>>>> ccd9c4e (ROS2 Humble migration)
                             detections,
                             0,                //hit threshold: decrease in order to increase number of detections but also false alarms
                             cv::Size(8,8),    //win stride
                             cv::Size(0,0),    //padding 24,16
                             1.02,             //scaling
                             1,                //final threshold
+<<<<<<< HEAD
                             false);            //use mean-shift to fuse detections
 
   double stop = static_cast<double>(cv::getTickCount());
   ROS_DEBUG_STREAM("Elapsed time in detectMultiScale: " << 1000.0*(stop-start)/cv::getTickFrequency() << " ms");
+=======
+                            false);           //use mean-shift to fuse detections
+
+  double stop = static_cast<double>(cv::getTickCount());
+  RCLCPP_DEBUG(this->get_logger(), "Elapsed time in detectMultiScale: %f ms", 
+               1000.0 * (stop - start) / cv::getTickFrequency());
+>>>>>>> ccd9c4e (ROS2 Humble migration)
 }
 
 void PersonDetector::publishDetections(const std::vector<cv::Rect>& detections) const
 {
+<<<<<<< HEAD
   pal_detection_msgs::Detections2d msg;
   pal_detection_msgs::Detection2d detection;
 
@@ -221,17 +346,41 @@ void PersonDetector::publishDetections(const std::vector<cv::Rect>& detections) 
   }
 
   _detectionPub.publish(msg);
+=======
+  auto msg = std::make_unique<pal_person_detector_opencv::msg::Detections2d>();
+  pal_person_detector_opencv::msg::Detection2d detection;
+
+  msg->header.frame_id = "";
+  msg->header.stamp = img_time_stamp_;
+
+  for (const auto& roi : detections)
+  {
+    detection.x = roi.x;
+    detection.y = roi.y;
+    detection.width = roi.width;
+    detection.height = roi.height;
+
+    msg->detections.push_back(detection);
+  }
+
+  detection_pub_->publish(std::move(msg));
+>>>>>>> ccd9c4e (ROS2 Humble migration)
 }
 
 void PersonDetector::publishDebugImage(cv::Mat& img,
                                        const std::vector<cv::Rect>& detections) const
 {
   //draw detections
+<<<<<<< HEAD
   BOOST_FOREACH(const cv::Rect& roi, detections)
+=======
+  for (const auto& roi : detections)
+>>>>>>> ccd9c4e (ROS2 Humble migration)
   {
     cv::rectangle(img, roi, CV_RGB(0,255,0), 2);
   }
 
+<<<<<<< HEAD
   if ( img.channels() == 3 && img.depth() == CV_8U )
     _cvImgDebug.encoding = sensor_msgs::image_encodings::BGR8;
 
@@ -246,10 +395,26 @@ void PersonDetector::publishDebugImage(cv::Mat& img,
   _cvImgDebug.toImageMsg(imgMsg); //copy image data to ROS message
 
   _imDebugPub.publish(imgMsg);
+=======
+  if (img.channels() == 3 && img.depth() == CV_8U)
+    cv_img_debug_.encoding = sensor_msgs::image_encodings::BGR8;
+  else if (img.channels() == 1 && img.depth() == CV_8U)
+    cv_img_debug_.encoding = sensor_msgs::image_encodings::MONO8;
+  else
+    throw std::runtime_error("Error in Detector2dNode::publishDebug: only 24-bit BGR or 8-bit MONO images are currently supported");
+
+  cv_img_debug_.image = img;
+  auto imgMsg = std::make_unique<sensor_msgs::msg::Image>();
+  imgMsg->header.stamp = img_time_stamp_;
+  cv_img_debug_.toImageMsg(*imgMsg); //copy image data to ROS message
+
+  im_debug_pub_.publish(std::move(imgMsg));
+>>>>>>> ccd9c4e (ROS2 Humble migration)
 }
 
 int main(int argc, char **argv)
 {
+<<<<<<< HEAD
   ros::init(argc,argv,"pal_person_detector_opencv"); // Create and name the Node
   ros::NodeHandle nh, pnh("~");
 
@@ -288,3 +453,10 @@ int main(int argc, char **argv)
 
   return 0;
 }
+=======
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<PersonDetector>());
+  rclcpp::shutdown();
+  return 0;
+}
+>>>>>>> ccd9c4e (ROS2 Humble migration)


### PR DESCRIPTION
This pull request migrates the PAL Person Detector package from ROS1 to ROS2 Humble. The person detector uses OpenCV's HOG (Histogram of Oriented Gradients) algorithm to detect people in camera streams.
**Key Changes**

- Updated build system from catkin to ament_cmake
- Converted message definitions to ROS2 format
- Integrated message generation within the package
- Restructured C++ code to use ROS2 Node API
- Converted launch files from XML to Python format
- Updated parameter handling for ROS2
- Replaced deprecated image transport mechanisms
- Added comprehensive README

**Features**

- Real-time person detection using OpenCV
- Configurable image scaling and processing rates
- Debug visualization with bounding boxes
- Standardized message interfaces for detection results

**Testing**
Package has been tested with:

- USB webcam input
- Various scale and rate parameters
- ROS2 Humble on Ubuntu 22.04